### PR TITLE
Add finer control of file mods/deletion checks. Resolves #65

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.0.0.9006
+Version: 0.0.0.9007
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# hubValidations 0.0.0.9007
+
+* `validate_pr()` now has arguments for controlling modification/deletions check are performed on model output and model metadata files (#65).
+  - `file_modify_check`, which controls whether modification/deletion checks are performed and what is retuned if modifications/deletions detected.
+  - `allow_submit_window_mods`, which controls whether modifications/deletions of model output files are allowed within their submission windows.
+
+
 # hubValidations 0.0.0.9006
 
 * `validate_pr()` now checks for deletions of previously submitted model metadata files and modifications or deletions of previously submitted model output files, adding an `<error/check_error>` class object to the function output for each detected modified/deleted file (#43 & #44).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # hubValidations 0.0.0.9007
 
 * `validate_pr()` now has arguments for controlling modification/deletions check are performed on model output and model metadata files (#65).
-  - `file_modify_check`, which controls whether modification/deletion checks are performed and what is retuned if modifications/deletions detected.
+  - `file_modification_check`, which controls whether modification/deletion checks are performed and what is returned if modifications/deletions detected.
   - `allow_submit_window_mods`, which controls whether modifications/deletions of model output files are allowed within their submission windows.
 
 

--- a/R/check_submission_time.R
+++ b/R/check_submission_time.R
@@ -1,10 +1,13 @@
 #' Checks submission is within the valid submission window for a given round.
 #'
-#' @param ref_date_from whether to get the round ID around which relative submission
-#' windows will be determined from the file's `file_path` or the `file` contents
-#' themselves. `file` requires that the file can be read.
+#' @param ref_date_from whether to get the reference date around
+#' which relative submission windows will be determined from the file's
+#' `file_path` round ID or the `file` contents themselves.
+#' `file` requires that the file can be read.
 #' Only applicable when a round is configured to determine the submission
 #' windows relative to the value in a date column in model output files.
+#' Not applicable when explicit submission window start and end dates are
+#' provided in the hub's config.
 #'
 #' @inherit check_tbl_col_types params return
 #'

--- a/R/check_submission_time.R
+++ b/R/check_submission_time.R
@@ -1,34 +1,20 @@
 #' Checks submission is within the valid submission window for a given round.
 #'
+#' @param ref_date_from whether to get the round ID around which relative submission
+#' windows will be determined from the file's `file_path` or the `file` contents
+#' themselves. `file` requires that the file can be read.
+#' Only applicable when a round is configured to determine the submission
+#' windows relative to the value in a date column in model output files.
+#'
 #' @inherit check_tbl_col_types params return
 #'
 #' @importFrom lubridate %within%
 #' @export
-check_submission_time <- function(hub_path, file_path) {
-  config_tasks <- hubUtils::read_config(hub_path, "tasks")
-  submission_config <- get_file_round_config(file_path, hub_path)[["submissions_due"]]
-  hub_tz <- get_hub_timezone(hub_path)
-
-  if (!is.null(submission_config[["relative_to"]])) {
-    tbl <- read_model_out_file(
-      file_path = file_path,
-      hub_path = hub_path
-    )
-    relative_date <- as.Date(
-      unique(tbl[[submission_config[["relative_to"]]]])
-    )
-    submission_window <- get_submission_window(
-      start = relative_date + submission_config[["start"]],
-      end = relative_date + submission_config[["end"]],
-      hub_tz
-    )
-  } else {
-    submission_window <- get_submission_window(
-      start = submission_config[["start"]],
-      end = submission_config[["end"]],
-      hub_tz
-    )
-  }
+check_submission_time <- function(hub_path, file_path, ref_date_from = c(
+                                    "file",
+                                    "file_path"
+                                  )) {
+  submission_window <- get_submission_window(hub_path, file_path, ref_date_from)
   check <- Sys.time() %within% submission_window
 
   if (check) {
@@ -48,7 +34,37 @@ check_submission_time <- function(hub_path, file_path) {
   )
 }
 
-get_submission_window <- function(start, end, hub_tz) {
+get_submission_window <- function(hub_path, file_path, ref_date_from = c(
+                                    "file",
+                                    "file_path"
+                                  )) {
+  ref_date_from <- rlang::arg_match(ref_date_from)
+  config_tasks <- hubUtils::read_config(hub_path, "tasks")
+  submission_config <- get_file_round_config(file_path, hub_path)[["submissions_due"]]
+  hub_tz <- get_hub_timezone(hub_path)
+
+  if (!is.null(submission_config[["relative_to"]])) {
+    relative_date <- switch(ref_date_from,
+      file_path = {
+        as.Date(get_file_round_id(file_path))
+      },
+      file = {
+        tbl <- read_model_out_file(
+          file_path = file_path,
+          hub_path = hub_path
+        )
+        as.Date(
+          unique(tbl[[submission_config[["relative_to"]]]])
+        )
+      }
+    )
+    start <- relative_date + submission_config[["start"]]
+    end <- relative_date + submission_config[["end"]]
+  } else {
+    start <- submission_config[["start"]]
+    end <- submission_config[["end"]]
+  }
+
   submit_window_start <- lubridate::ymd(start, tz = hub_tz)
   submit_window_end <- lubridate::ymd_hms(paste(end, "23:59:59"),
     tz = hub_tz
@@ -58,4 +74,12 @@ get_submission_window <- function(start, end, hub_tz) {
     start = submit_window_start,
     end = submit_window_end
   )
+}
+
+file_within_submission_window <- function(hub_path, file_path, ref_date_from = c(
+                                            "file",
+                                            "file_path"
+                                          )) {
+  submission_window <- get_submission_window(hub_path, file_path, ref_date_from)
+  Sys.time() %within% submission_window
 }

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -271,5 +271,6 @@ check_pr_modf_del_files <- function(pr_df, file_type = c(
       )
     )
   }
-  as_hub_validations(out)
+  as_hub_validations(out) %>%
+    purrr::set_names(sprintf("%s_mod_%i", file_type, seq_along(out)))
 }

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -33,7 +33,7 @@
 #' and return a `<error/check_error>` condition class object for each
 #' applicable modified/deleted file. This behaviour can be modified through
 #' arguments `file_modify_check`, which controls whether modification/deletion
-#' checks are performed and what is retuned if modifications/deletions detected,
+#' checks are performed and what is retuned if modifications/deletions are detected,
 #' and `allow_submit_window_mods`, which controls whether modifications/deletions
 #' of model output files are allowed within their submission windows.
 #'

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -189,10 +189,7 @@ inform_unvalidated_files <- function(pr_df) {
     return(invisible(NULL))
   }
 
-  unvalidated_bullets <- purrr::map_chr(
-    unvalidated_files,
-    ~ paste0("{.val ", .x, "}")
-  ) %>%
+  unvalidated_bullets <- sprintf("{.val %s}", unvalidated_files) %>%
     purrr::set_names(rep("*", length(unvalidated_files)))
 
   cli::cli_inform(

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -40,7 +40,7 @@
 #' Note that to establish **relative** submission windows when performing
 #' modification/deletion checks and `allow_submit_window_mods`
 #' is `TRUE`, the _relative to_ date is considered as the `round_id` extracted from
-#' the file path (i.e. `submit_window_ref_date_from` is always set to `"file_path`).
+#' the file path (i.e. `submit_window_ref_date_from` is always set to `"file_path"`).
 #' This is because we cannot extract dates from columns of deleted
 #' files. If hub _relative to_ dates do not match the round IDs in file paths,
 #' currently `allow_submit_window_mods` will not work correctly and is best set

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -203,7 +203,7 @@ inform_unvalidated_files <- function(pr_df) {
   )
 }
 # Checks for model output file modifications and model output & model metadata
-# file deletions. Returns an <error/check_error>⁠ condition class object if any
+# file deletions/renaming. Returns an <error/check_error>⁠ condition class object if any
 # modification or deletion detected.
 check_pr_modf_del_files <- function(pr_df, file_type = c(
                                       "model_output",
@@ -214,8 +214,9 @@ check_pr_modf_del_files <- function(pr_df, file_type = c(
   file_type <- rlang::arg_match(file_type)
   alert <- rlang::arg_match(alert)
 
-  # subset pr_df to the file type beiing checked. We check model output and model
-  # metadata files separately as model metadata files are only check for deletions.
+  # subset pr_df to the file type being checked. We check model output and model
+  # metadata files separately as model metadata files are only checked for
+  # deletions/renaming.
   # Also, they have no submission window so deletions are not affected by
   # allow_submit_window_mods
   df <- pr_df[pr_df[[file_type]], ]
@@ -229,7 +230,7 @@ check_pr_modf_del_files <- function(pr_df, file_type = c(
     return(new_hub_validations())
   }
   # Check whether modifications allowed and return notification object according
-  # to alert for any file that violates allowed mod/del.
+  # to alert for any file that violates allowed mod/del rules.
   out <- purrr::map(
     .x = 1:nrow(df),
     ~ check_pr_modf_del_file(

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -33,7 +33,7 @@
 #' and return a `<error/check_error>` condition class object for each
 #' applicable modified/deleted file. This behaviour can be modified through
 #' arguments `file_modify_check`, which controls whether modification/deletion
-#' checks are performed and what is retuned if modifications/deletions are detected,
+#' checks are performed and what is returned if modifications/deletions are detected,
 #' and `allow_submit_window_mods`, which controls whether modifications/deletions
 #' of model output files are allowed within their submission windows.
 #'

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -39,10 +39,10 @@
 #'
 #' Note that to establish **relative** submission windows when performing
 #' modification/deletion checks and `allow_submit_window_mods`
-#' is `TRUE`, the _relative to_ date is considered as the `round_id` extracted from
+#' is `TRUE`, the reference date is taken as the `round_id` extracted from
 #' the file path (i.e. `submit_window_ref_date_from` is always set to `"file_path"`).
 #' This is because we cannot extract dates from columns of deleted
-#' files. If hub _relative to_ dates do not match the round IDs in file paths,
+#' files. If hub submission window reference dates do not match round IDs in file paths,
 #' currently `allow_submit_window_mods` will not work correctly and is best set
 #' to `FALSE`. This only relates to hubs/rounds where submission windows are
 #' determined relative to a reference date and not when explicit submission

--- a/R/validate_submission.R
+++ b/R/validate_submission.R
@@ -6,11 +6,14 @@
 #' @param skip_submit_window_check Logical. Whether to skip the submission window check.
 #' @param skip_check_config Logical. Whether to skip the hub config validation check.
 #'  check.
-#' @param submit_window_ref_date_from whether to get the round ID around which relative submission
-#' windows will be determined from the file's `file_path` or the `file` contents
-#' themselves. `file` requires that the file can be read.
+#' @param submit_window_ref_date_from whether to get the reference date around
+#' which relative submission windows will be determined from the file's
+#' `file_path` round ID or the `file` contents themselves.
+#' `file` requires that the file can be read.
 #' Only applicable when a round is configured to determine the submission
 #' windows relative to the value in a date column in model output files.
+#' Not applicable when explicit submission window start and end dates are
+#' provided in the hub's config.
 #' @export
 #'
 #' @examples

--- a/R/validate_submission.R
+++ b/R/validate_submission.R
@@ -6,6 +6,11 @@
 #' @param skip_submit_window_check Logical. Whether to skip the submission window check.
 #' @param skip_check_config Logical. Whether to skip the hub config validation check.
 #'  check.
+#' @param submit_window_ref_date_from whether to get the round ID around which relative submission
+#' windows will be determined from the file's `file_path` or the `file` contents
+#' themselves. `file` requires that the file can be read.
+#' Only applicable when a round is configured to determine the submission
+#' windows relative to the value in a date column in model output files.
 #' @export
 #'
 #' @examples
@@ -15,7 +20,11 @@
 validate_submission <- function(hub_path, file_path, round_id_col = NULL,
                                 validations_cfg_path = NULL,
                                 skip_submit_window_check = FALSE,
-                                skip_check_config = FALSE) {
+                                skip_check_config = FALSE,
+                                submit_window_ref_date_from = c(
+                                  "file",
+                                  "file_path"
+                                )) {
   check_hub_config <- new_hub_validations()
   if (!skip_check_config) {
     check_hub_config$valid_config <- try_check(
@@ -30,7 +39,10 @@ validate_submission <- function(hub_path, file_path, round_id_col = NULL,
   if (skip_submit_window_check) {
     checks_submission_time <- new_hub_validations()
   } else {
-    checks_submission_time <- validate_submission_time(hub_path, file_path)
+    checks_submission_time <- validate_submission_time(
+      hub_path, file_path,
+      ref_date_from = submit_window_ref_date_from
+    )
   }
 
   checks_file <- validate_model_file(

--- a/R/validate_submission_time.R
+++ b/R/validate_submission_time.R
@@ -1,19 +1,24 @@
 #' Validate a submitted model data file submission time.
 #'
 #' @inherit validate_model_data return params
+#' @inheritParams check_submission_time
 #' @export
 #'
 #' @examples
 #' hub_path <- system.file("testhubs/simple", package = "hubValidations")
 #' file_path <- "team1-goodmodel/2022-10-08-team1-goodmodel.csv"
 #' validate_submission_time(hub_path, file_path)
-validate_submission_time <- function(hub_path, file_path) {
+validate_submission_time <- function(hub_path, file_path, ref_date_from = c(
+                                       "file_path",
+                                       "file"
+                                     )) {
   checks <- new_hub_validations()
 
   checks$submission_time <- try_check(
     check_submission_time(
       file_path = file_path,
-      hub_path = hub_path
+      hub_path = hub_path,
+      ref_date_from = ref_date_from
     ),
     file_path = file_path
   )

--- a/man/check_submission_time.Rd
+++ b/man/check_submission_time.Rd
@@ -4,7 +4,11 @@
 \alias{check_submission_time}
 \title{Checks submission is within the valid submission window for a given round.}
 \usage{
-check_submission_time(hub_path, file_path)
+check_submission_time(
+  hub_path,
+  file_path,
+  ref_date_from = c("file", "file_path")
+)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
@@ -19,6 +23,12 @@ files within the \code{hub-config} directory.}
 
 \item{file_path}{character string. Path to the file being validated relative to
 the hub's model-output directory.}
+
+\item{ref_date_from}{whether to get the round ID around which relative submission
+windows will be determined from the file's \code{file_path} or the \code{file} contents
+themselves. \code{file} requires that the file can be read.
+Only applicable when a round is configured to determine the submission
+windows relative to the value in a date column in model output files.}
 }
 \value{
 Depending on whether validation has succeeded, one of:

--- a/man/check_submission_time.Rd
+++ b/man/check_submission_time.Rd
@@ -24,11 +24,14 @@ files within the \code{hub-config} directory.}
 \item{file_path}{character string. Path to the file being validated relative to
 the hub's model-output directory.}
 
-\item{ref_date_from}{whether to get the round ID around which relative submission
-windows will be determined from the file's \code{file_path} or the \code{file} contents
-themselves. \code{file} requires that the file can be read.
+\item{ref_date_from}{whether to get the reference date around
+which relative submission windows will be determined from the file's
+\code{file_path} round ID or the \code{file} contents themselves.
+\code{file} requires that the file can be read.
 Only applicable when a round is configured to determine the submission
-windows relative to the value in a date column in model output files.}
+windows relative to the value in a date column in model output files.
+Not applicable when explicit submission window start and end dates are
+provided in the hub's config.}
 }
 \value{
 Depending on whether validation has succeeded, one of:

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -83,7 +83,7 @@ files and deletions of previously submitted model metadata files are not allowed
 and return a \verb{<error/check_error>} condition class object for each
 applicable modified/deleted file. This behaviour can be modified through
 arguments \code{file_modify_check}, which controls whether modification/deletion
-checks are performed and what is retuned if modifications/deletions are detected,
+checks are performed and what is returned if modifications/deletions are detected,
 and \code{allow_submit_window_mods}, which controls whether modifications/deletions
 of model output files are allowed within their submission windows.
 

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -57,11 +57,14 @@ applicable modified/deleted file.
 \item{allow_submit_window_mods}{Logical. Whether to allow modifications/deletions
 of model output files within their submission windows. Defaults to \code{TRUE}.}
 
-\item{submit_window_ref_date_from}{whether to get the round ID around which relative submission
-windows will be determined from the file's \code{file_path} or the \code{file} contents
-themselves. \code{file} requires that the file can be read.
+\item{submit_window_ref_date_from}{whether to get the reference date around
+which relative submission windows will be determined from the file's
+\code{file_path} round ID or the \code{file} contents themselves.
+\code{file} requires that the file can be read.
 Only applicable when a round is configured to determine the submission
-windows relative to the value in a date column in model output files.}
+windows relative to the value in a date column in model output files.
+Not applicable when explicit submission window start and end dates are
+provided in the hub's config.}
 }
 \value{
 An object of class \code{hub_validations}.
@@ -86,10 +89,10 @@ of model output files are allowed within their submission windows.
 
 Note that to establish \strong{relative} submission windows when performing
 modification/deletion checks and \code{allow_submit_window_mods}
-is \code{TRUE}, the \emph{relative to} date is considered as the \code{round_id} extracted from
+is \code{TRUE}, the reference date is taken as the \code{round_id} extracted from
 the file path (i.e. \code{submit_window_ref_date_from} is always set to \code{"file_path"}).
 This is because we cannot extract dates from columns of deleted
-files. If hub \emph{relative to} dates do not match the round IDs in file paths,
+files. If hub submission window reference dates do not match round IDs in file paths,
 currently \code{allow_submit_window_mods} will not work correctly and is best set
 to \code{FALSE}. This only relates to hubs/rounds where submission windows are
 determined relative to a reference date and not when explicit submission

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -10,7 +10,10 @@ validate_pr(
   pr_number,
   round_id_col = NULL,
   validations_cfg_path = NULL,
-  skip_submit_window_check = FALSE
+  skip_submit_window_check = FALSE,
+  file_modify_check = c("error", "warn", "message", "none"),
+  allow_submit_window_mods = TRUE,
+  submit_window_ref_date_from = c("file", "file_path")
 )
 }
 \arguments{
@@ -37,12 +40,60 @@ details but has not been configured via \code{round_id_from_variable: true} and
 defaults to \code{hub-config/validations.yml}.}
 
 \item{skip_submit_window_check}{Logical. Whether to skip the submission window check.}
+
+\item{file_modify_check}{Character string. Whether to perform check and what to
+return when modification/deletion of a previously submitted model output file
+or deletion of a previously submitted model metadata file is detected in PR:
+\itemize{
+\item \code{"error"}: Appends a \verb{<error/check_error>} condition class object for each
+applicable modified/deleted file.
+\item \code{"warning"}: Appends a \verb{<warning/check_warning>} condition class object for each
+applicable modified/deleted file.
+\item \code{"message"}: Appends a \verb{<message/check_info>} condition class object for each
+applicable modified/deleted file.
+\item \code{"none"}: No modification/deletion checks performed.
+}}
+
+\item{allow_submit_window_mods}{Logical. Whether to allow modifications/deletions
+of model output files within their submission windows. Defaults to \code{TRUE}.}
+
+\item{submit_window_ref_date_from}{whether to get the round ID around which relative submission
+windows will be determined from the file's \code{file_path} or the \code{file} contents
+themselves. \code{file} requires that the file can be read.
+Only applicable when a round is configured to determine the submission
+windows relative to the value in a date column in model output files.}
 }
 \value{
 An object of class \code{hub_validations}.
 }
 \description{
-Validate Pull Request
+Validates model output and model metadata files in a Pull Request.
+}
+\details{
+Only model output and model metadata files are individually validated using
+\code{validate_submission()} with each file although as part of checks, hub config
+files are also validated. Any other files included in the PR are ignored but
+flagged in a message.
+
+By default, modifications and deletions of previously submitted model output
+files and deletions of previously submitted model metadata files are not allowed
+and return a \verb{<error/check_error>} condition class object for each
+applicable modified/deleted file. This behaviour can be modified through
+arguments \code{file_modify_check}, which controls whether modification/deletion
+checks are performed and what is retuned if modifications/deletions detected,
+and \code{allow_submit_window_mods}, which controls whether modifications/deletions
+of model output files are allowed within their submission windows.
+
+Note that to establish \strong{relative} submission windows when performing
+modification/deletion checks and \code{allow_submit_window_mods}
+is \code{TRUE}, the \emph{relative to} date is considered as the \code{round_id} extracted from
+the file path (i.e. \code{submit_window_ref_date_from} is always set to \verb{"file_path}).
+This is because we cannot extract dates from columns of deleted
+files. If hub \emph{relative to} dates do not match the round IDs in file paths,
+currently \code{allow_submit_window_mods} will not work correctly and is best set
+to \code{FALSE}. This only relates to hubs/rounds where submission windows are
+determined relative to a reference date and not when explicit submission
+window start and end dates are provided in the config.
 }
 \examples{
 \dontrun{

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -11,7 +11,7 @@ validate_pr(
   round_id_col = NULL,
   validations_cfg_path = NULL,
   skip_submit_window_check = FALSE,
-  file_modify_check = c("error", "warn", "message", "none"),
+  file_modification_check = c("error", "warn", "message", "none"),
   allow_submit_window_mods = TRUE,
   submit_window_ref_date_from = c("file", "file_path")
 )
@@ -41,7 +41,7 @@ defaults to \code{hub-config/validations.yml}.}
 
 \item{skip_submit_window_check}{Logical. Whether to skip the submission window check.}
 
-\item{file_modify_check}{Character string. Whether to perform check and what to
+\item{file_modification_check}{Character string. Whether to perform check and what to
 return when modification/deletion of a previously submitted model output file
 or deletion of a previously submitted model metadata file is detected in PR:
 \itemize{
@@ -78,11 +78,12 @@ Only model output and model metadata files are individually validated using
 files are also validated. Any other files included in the PR are ignored but
 flagged in a message.
 
-By default, modifications and deletions of previously submitted model output
-files and deletions of previously submitted model metadata files are not allowed
+By default, modifications (which include renaming) and deletions of
+previously submitted model output files and deletions or renaming of
+previously submitted model metadata files are not allowed
 and return a \verb{<error/check_error>} condition class object for each
 applicable modified/deleted file. This behaviour can be modified through
-arguments \code{file_modify_check}, which controls whether modification/deletion
+arguments \code{file_modification_check}, which controls whether modification/deletion
 checks are performed and what is returned if modifications/deletions are detected,
 and \code{allow_submit_window_mods}, which controls whether modifications/deletions
 of model output files are allowed within their submission windows.

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -80,7 +80,7 @@ files and deletions of previously submitted model metadata files are not allowed
 and return a \verb{<error/check_error>} condition class object for each
 applicable modified/deleted file. This behaviour can be modified through
 arguments \code{file_modify_check}, which controls whether modification/deletion
-checks are performed and what is retuned if modifications/deletions detected,
+checks are performed and what is retuned if modifications/deletions are detected,
 and \code{allow_submit_window_mods}, which controls whether modifications/deletions
 of model output files are allowed within their submission windows.
 

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -87,7 +87,7 @@ of model output files are allowed within their submission windows.
 Note that to establish \strong{relative} submission windows when performing
 modification/deletion checks and \code{allow_submit_window_mods}
 is \code{TRUE}, the \emph{relative to} date is considered as the \code{round_id} extracted from
-the file path (i.e. \code{submit_window_ref_date_from} is always set to \verb{"file_path}).
+the file path (i.e. \code{submit_window_ref_date_from} is always set to \code{"file_path"}).
 This is because we cannot extract dates from columns of deleted
 files. If hub \emph{relative to} dates do not match the round IDs in file paths,
 currently \code{allow_submit_window_mods} will not work correctly and is best set

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -42,11 +42,14 @@ defaults to \code{hub-config/validations.yml}.}
 \item{skip_check_config}{Logical. Whether to skip the hub config validation check.
 check.}
 
-\item{submit_window_ref_date_from}{whether to get the round ID around which relative submission
-windows will be determined from the file's \code{file_path} or the \code{file} contents
-themselves. \code{file} requires that the file can be read.
+\item{submit_window_ref_date_from}{whether to get the reference date around
+which relative submission windows will be determined from the file's
+\code{file_path} round ID or the \code{file} contents themselves.
+\code{file} requires that the file can be read.
 Only applicable when a round is configured to determine the submission
-windows relative to the value in a date column in model output files.}
+windows relative to the value in a date column in model output files.
+Not applicable when explicit submission window start and end dates are
+provided in the hub's config.}
 }
 \value{
 An object of class \code{hub_validations}. Each named element contains

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -12,7 +12,8 @@ validate_submission(
   round_id_col = NULL,
   validations_cfg_path = NULL,
   skip_submit_window_check = FALSE,
-  skip_check_config = FALSE
+  skip_check_config = FALSE,
+  submit_window_ref_date_from = c("file", "file_path")
 )
 }
 \arguments{
@@ -40,6 +41,12 @@ defaults to \code{hub-config/validations.yml}.}
 
 \item{skip_check_config}{Logical. Whether to skip the hub config validation check.
 check.}
+
+\item{submit_window_ref_date_from}{whether to get the round ID around which relative submission
+windows will be determined from the file's \code{file_path} or the \code{file} contents
+themselves. \code{file} requires that the file can be read.
+Only applicable when a round is configured to determine the submission
+windows relative to the value in a date column in model output files.}
 }
 \value{
 An object of class \code{hub_validations}. Each named element contains

--- a/man/validate_submission_time.Rd
+++ b/man/validate_submission_time.Rd
@@ -4,7 +4,11 @@
 \alias{validate_submission_time}
 \title{Validate a submitted model data file submission time.}
 \usage{
-validate_submission_time(hub_path, file_path)
+validate_submission_time(
+  hub_path,
+  file_path,
+  ref_date_from = c("file_path", "file")
+)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
@@ -19,6 +23,12 @@ files within the \code{hub-config} directory.}
 
 \item{file_path}{character string. Path to the file being validated relative to
 the hub's model-output directory.}
+
+\item{ref_date_from}{whether to get the round ID around which relative submission
+windows will be determined from the file's \code{file_path} or the \code{file} contents
+themselves. \code{file} requires that the file can be read.
+Only applicable when a round is configured to determine the submission
+windows relative to the value in a date column in model output files.}
 }
 \value{
 An object of class \code{hub_validations}. Each named element contains

--- a/man/validate_submission_time.Rd
+++ b/man/validate_submission_time.Rd
@@ -24,11 +24,14 @@ files within the \code{hub-config} directory.}
 \item{file_path}{character string. Path to the file being validated relative to
 the hub's model-output directory.}
 
-\item{ref_date_from}{whether to get the round ID around which relative submission
-windows will be determined from the file's \code{file_path} or the \code{file} contents
-themselves. \code{file} requires that the file can be read.
+\item{ref_date_from}{whether to get the reference date around
+which relative submission windows will be determined from the file's
+\code{file_path} round ID or the \code{file} contents themselves.
+\code{file} requires that the file can be read.
 Only applicable when a round is configured to determine the submission
-windows relative to the value in a date column in model output files.}
+windows relative to the value in a date column in model output files.
+Not applicable when explicit submission window start and end dates are
+provided in the hub's config.}
 }
 \value{
 An object of class \code{hub_validations}. Each named element contains

--- a/tests/testthat/_snaps/validate_pr.md
+++ b/tests/testthat/_snaps/validate_pr.md
@@ -228,7 +228,7 @@
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
        $ model_output_mod_2  :List of 6
@@ -236,7 +236,7 @@
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
        $ model_metadata_mod_1:List of 6
@@ -244,7 +244,7 @@
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
        $ file_exists         :List of 4
@@ -418,19 +418,19 @@
        $ model_output_mod_1  :List of 4
         ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
        $ model_output_mod_2  :List of 4
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
        $ model_metadata_mod_1:List of 4
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
        $ file_exists         :List of 4
@@ -604,19 +604,19 @@
        $ model_output_mod_1  :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/hub-baseline/2022-10-08-hub-baseline.csv' modified."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
        $ model_output_mod_2  :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/team1-goodmodel/2022-10-15-team1-goodmodel.csv' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
        $ model_metadata_mod_1:List of 4
         ..$ message       : chr "Previously submitted model metadata file\n          'model-metadata/team1-goodmodel.yaml' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
        $ file_exists         :List of 4
@@ -960,7 +960,7 @@
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
        $ model_metadata_mod_1:List of 6
@@ -968,7 +968,7 @@
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
-        ..$ call          : chr ".f"
+        ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
        $ file_exists         :List of 4
@@ -1126,4 +1126,43 @@
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+
+# validate_pr handles errors in determining submission window & file renaming
+
+    Code
+      str(mod_checks_exec_error[1:5])
+    Output
+      List of 5
+       $ valid_config      :List of 4
+        ..$ message       : chr "All hub config files are valid. \n "
+        ..$ where         : chr "mod_exec_error_hub"
+        ..$ call          : chr "check_config_hub_valid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ model_output_mod_1:List of 6
+        ..$ message       : chr "Could not check submission window for file \"team1-goodmodel/2022-10-team1-goodmodel.csv\". EXEC ERROR: Error i"| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-team1-goodmodel.csv"
+        ..$ call          : chr "check_pr_modf_del_file"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_exec_error" "hub_check" "rlang_error" "error" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
 

--- a/tests/testthat/_snaps/validate_pr.md
+++ b/tests/testthat/_snaps/validate_pr.md
@@ -217,13 +217,13 @@
       str(mod_checks_error)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
-       $ valid_config      :List of 4
+       $ valid_config        :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $                   :List of 6
+       $ model_output_mod_1  :List of 6
         ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -231,7 +231,7 @@
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $                   :List of 6
+       $ model_output_mod_2  :List of 6
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -239,7 +239,7 @@
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $                   :List of 6
+       $ model_metadata_mod_1:List of 6
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -247,92 +247,92 @@
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 4
+       $ metadata_exists     :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read         :List of 4
+       $ file_read           :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col:List of 4
+       $ valid_round_id_col  :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id   :List of 4
+       $ unique_round_id     :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id    :List of 4
+       $ match_round_id      :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames          :List of 4
+       $ colnames            :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types         :List of 4
+       $ col_types           :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals        :List of 5
+       $ valid_vals          :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique       :List of 4
+       $ rows_unique         :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals          :List of 5
+       $ req_vals            :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -345,56 +345,56 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid   :List of 4
+       $ value_col_valid     :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc:List of 5
+       $ value_col_non_desc  :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1    :List of 4
+       $ value_col_sum1      :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 6
+       $ metadata_exists     :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -409,116 +409,116 @@
       str(mod_checks_warn)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
-       $ valid_config      :List of 4
+       $ valid_config        :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $                   :List of 4
+       $ model_output_mod_1  :List of 4
         ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
-       $                   :List of 4
+       $ model_output_mod_2  :List of 4
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
-       $                   :List of 4
+       $ model_metadata_mod_1:List of 4
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 4
+       $ metadata_exists     :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read         :List of 4
+       $ file_read           :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col:List of 4
+       $ valid_round_id_col  :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id   :List of 4
+       $ unique_round_id     :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id    :List of 4
+       $ match_round_id      :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames          :List of 4
+       $ colnames            :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types         :List of 4
+       $ col_types           :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals        :List of 5
+       $ valid_vals          :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique       :List of 4
+       $ rows_unique         :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals          :List of 5
+       $ req_vals            :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -531,56 +531,56 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid   :List of 4
+       $ value_col_valid     :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc:List of 5
+       $ value_col_non_desc  :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1    :List of 4
+       $ value_col_sum1      :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 6
+       $ metadata_exists     :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -595,116 +595,116 @@
       str(mod_checks_message)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
-       $ valid_config      :List of 4
+       $ valid_config        :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $                   :List of 4
+       $ model_output_mod_1  :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/hub-baseline/2022-10-08-hub-baseline.csv' modified."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $                   :List of 4
+       $ model_output_mod_2  :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/team1-goodmodel/2022-10-15-team1-goodmodel.csv' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $                   :List of 4
+       $ model_metadata_mod_1:List of 4
         ..$ message       : chr "Previously submitted model metadata file\n          'model-metadata/team1-goodmodel.yaml' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 4
+       $ metadata_exists     :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read         :List of 4
+       $ file_read           :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col:List of 4
+       $ valid_round_id_col  :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id   :List of 4
+       $ unique_round_id     :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id    :List of 4
+       $ match_round_id      :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames          :List of 4
+       $ colnames            :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types         :List of 4
+       $ col_types           :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals        :List of 5
+       $ valid_vals          :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique       :List of 4
+       $ rows_unique         :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals          :List of 5
+       $ req_vals            :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -717,56 +717,56 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid   :List of 4
+       $ value_col_valid     :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc:List of 5
+       $ value_col_non_desc  :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1    :List of 4
+       $ value_col_sum1      :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 6
+       $ metadata_exists     :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -949,13 +949,13 @@
       str(mod_checks_in_window)
     Output
       Classes 'hub_validations', 'list'  hidden list of 27
-       $ valid_config      :List of 4
+       $ valid_config        :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $                   :List of 6
+       $ model_output_mod_1  :List of 6
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -963,7 +963,7 @@
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $                   :List of 6
+       $ model_metadata_mod_1:List of 6
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -971,92 +971,92 @@
         ..$ call          : chr ".f"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 4
+       $ metadata_exists     :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read         :List of 4
+       $ file_read           :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col:List of 4
+       $ valid_round_id_col  :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id   :List of 4
+       $ unique_round_id     :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id    :List of 4
+       $ match_round_id      :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames          :List of 4
+       $ colnames            :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types         :List of 4
+       $ col_types           :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals        :List of 5
+       $ valid_vals          :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique       :List of 4
+       $ rows_unique         :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals          :List of 5
+       $ req_vals            :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -1069,56 +1069,56 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid   :List of 4
+       $ value_col_valid     :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc:List of 5
+       $ value_col_non_desc  :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1    :List of 4
+       $ value_col_sum1      :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists       :List of 4
+       $ file_exists         :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name         :List of 4
+       $ file_name           :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location     :List of 4
+       $ file_location       :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid    :List of 4
+       $ round_id_valid      :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format       :List of 4
+       $ file_format         :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists   :List of 6
+       $ metadata_exists     :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL

--- a/tests/testthat/_snaps/validate_pr.md
+++ b/tests/testthat/_snaps/validate_pr.md
@@ -133,7 +133,7 @@
 # validate_pr works on invalid PR
 
     Code
-      str(checks)
+      str(invalid_checks)
     Output
       Classes 'hub_validations', 'list'  hidden list of 12
        $ valid_config      :List of 4
@@ -214,7 +214,7 @@
 # validate_pr flags modifications and deletions in PR
 
     Code
-      str(checks)
+      str(mod_checks_error)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
        $ valid_config      :List of 4
@@ -406,7 +406,7 @@
 ---
 
     Code
-      str(checks)
+      str(mod_checks_warn)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
        $ valid_config      :List of 4
@@ -592,7 +592,7 @@
 ---
 
     Code
-      str(checks)
+      str(mod_checks_message)
     Output
       Classes 'hub_validations', 'list'  hidden list of 28
        $ valid_config      :List of 4
@@ -778,7 +778,7 @@
 ---
 
     Code
-      str(checks)
+      str(mod_checks_none)
     Output
       Classes 'hub_validations', 'list'  hidden list of 25
        $ valid_config      :List of 4
@@ -946,7 +946,7 @@
 ---
 
     Code
-      str(checks)
+      str(mod_checks_in_window)
     Output
       Classes 'hub_validations', 'list'  hidden list of 27
        $ valid_config      :List of 4

--- a/tests/testthat/_snaps/validate_pr.md
+++ b/tests/testthat/_snaps/validate_pr.md
@@ -403,3 +403,727 @@
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
 
+---
+
+    Code
+      str(checks)
+    Output
+      Classes 'hub_validations', 'list'  hidden list of 28
+       $ valid_config      :List of 4
+        ..$ message       : chr "All hub config files are valid. \n "
+        ..$ where         : chr "mod_del_hub"
+        ..$ call          : chr "check_config_hub_valid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
+        ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_warning" "warning" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 4
+        ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_read         :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col:List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id   :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id    :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames          :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types         :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals        :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique       :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals          :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid   :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc:List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1    :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 6
+        ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+
+---
+
+    Code
+      str(checks)
+    Output
+      Classes 'hub_validations', 'list'  hidden list of 28
+       $ valid_config      :List of 4
+        ..$ message       : chr "All hub config files are valid. \n "
+        ..$ where         : chr "mod_del_hub"
+        ..$ call          : chr "check_config_hub_valid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model output file\n          'model-output/hub-baseline/2022-10-08-hub-baseline.csv' modified."
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model output file\n          'model-output/team1-goodmodel/2022-10-15-team1-goodmodel.csv' removed."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $                   :List of 4
+        ..$ message       : chr "Previously submitted model metadata file\n          'model-metadata/team1-goodmodel.yaml' removed."
+        ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 4
+        ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_read         :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col:List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id   :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id    :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames          :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types         :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals        :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique       :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals          :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid   :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc:List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1    :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 6
+        ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+
+---
+
+    Code
+      str(checks)
+    Output
+      Classes 'hub_validations', 'list'  hidden list of 25
+       $ valid_config      :List of 4
+        ..$ message       : chr "All hub config files are valid. \n "
+        ..$ where         : chr "mod_del_hub"
+        ..$ call          : chr "check_config_hub_valid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 4
+        ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_read         :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col:List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id   :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id    :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames          :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types         :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals        :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique       :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals          :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid   :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc:List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1    :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 6
+        ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+
+---
+
+    Code
+      str(checks)
+    Output
+      Classes 'hub_validations', 'list'  hidden list of 27
+       $ valid_config      :List of 4
+        ..$ message       : chr "All hub config files are valid. \n "
+        ..$ where         : chr "mod_del_hub"
+        ..$ call          : chr "check_config_hub_valid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $                   :List of 6
+        ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+       $                   :List of 6
+        ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
+        ..$ call          : chr ".f"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 4
+        ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_read         :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col:List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id   :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id    :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames          :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types         :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals        :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique       :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals          :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid   :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc:List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1    :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ file_exists       :List of 4
+        ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_name         :List of 4
+        ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_name"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_location     :List of 4
+        ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_location"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ round_id_valid    :List of 4
+        ..$ message       : chr "`round_id` is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ file_format       :List of 4
+        ..$ message       : chr "File is accepted hub format. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_format"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ metadata_exists   :List of 6
+        ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
+        ..$ trace         : NULL
+        ..$ parent        : NULL
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_submission_metadata_file_exists"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+

--- a/tests/testthat/test-validate_pr.R
+++ b/tests/testthat/test-validate_pr.R
@@ -32,17 +32,17 @@ test_that("validate_pr works on invalid PR", {
     branch = "pr-missing-taskid"
   )
 
-  checks <- validate_pr(
+  invalid_checks <- validate_pr(
     hub_path = temp_hub,
     gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
     pr_number = 5,
     skip_submit_window_check = TRUE
   )
 
-  expect_snapshot(str(checks))
+  expect_snapshot(str(invalid_checks))
 
   expect_error(
-    suppressMessages(check_for_errors(checks))
+    suppressMessages(check_for_errors(invalid_checks))
   )
 })
 
@@ -56,7 +56,7 @@ test_that("validate_pr flags modifications and deletions in PR", {
     branch = "test-mod-del"
   )
 
-  checks <- suppressMessages(
+  mod_checks_error <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
@@ -65,12 +65,12 @@ test_that("validate_pr flags modifications and deletions in PR", {
     )
   )
 
-  expect_snapshot(str(checks))
+  expect_snapshot(str(mod_checks_error))
   expect_error(
-    suppressMessages(check_for_errors(checks))
+    suppressMessages(check_for_errors(mod_checks_error))
   )
 
-  checks <- suppressMessages(
+  mod_checks_warn <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
@@ -79,12 +79,12 @@ test_that("validate_pr flags modifications and deletions in PR", {
       file_modify_check = "warn"
     )
   )
-  expect_snapshot(str(checks))
+  expect_snapshot(str(mod_checks_warn))
   expect_error(
-    suppressMessages(check_for_errors(checks))
+    suppressMessages(check_for_errors(mod_checks_warn))
   )
 
-  checks <- suppressMessages(
+  mod_checks_message <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
@@ -93,13 +93,13 @@ test_that("validate_pr flags modifications and deletions in PR", {
       file_modify_check = "message"
     )
   )
-  expect_snapshot(str(checks))
+  expect_snapshot(str(mod_checks_message))
   expect_true(
-    suppressMessages(check_for_errors(checks[1:5]))
+    suppressMessages(check_for_errors(mod_checks_message[1:5]))
   )
 
 
-  checks <- suppressMessages(
+  mod_checks_none <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
@@ -108,9 +108,9 @@ test_that("validate_pr flags modifications and deletions in PR", {
       file_modify_check = "none"
     )
   )
-  expect_snapshot(str(checks))
+  expect_snapshot(str(mod_checks_none))
   expect_true(
-    suppressMessages(check_for_errors(checks[1:5]))
+    suppressMessages(check_for_errors(mod_checks_none[1:5]))
   )
 
   mockery::stub(
@@ -119,7 +119,7 @@ test_that("validate_pr flags modifications and deletions in PR", {
     lubridate::as_datetime("2022-10-08 18:01:00 EEST"),
     2
   )
-  checks <- suppressMessages(
+  mod_checks_in_window <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
@@ -128,5 +128,5 @@ test_that("validate_pr flags modifications and deletions in PR", {
       allow_submit_window_mods = TRUE
     )
   )
-  expect_snapshot(str(checks))
+  expect_snapshot(str(mod_checks_in_window))
 })

--- a/tests/testthat/test-validate_pr.R
+++ b/tests/testthat/test-validate_pr.R
@@ -76,7 +76,7 @@ test_that("validate_pr flags modifications and deletions in PR", {
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
       pr_number = 6,
       skip_submit_window_check = TRUE,
-      file_modify_check = "warn"
+      file_modification_check = "warn"
     )
   )
   expect_snapshot(str(mod_checks_warn))
@@ -90,7 +90,7 @@ test_that("validate_pr flags modifications and deletions in PR", {
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
       pr_number = 6,
       skip_submit_window_check = TRUE,
-      file_modify_check = "message"
+      file_modification_check = "message"
     )
   )
   expect_snapshot(str(mod_checks_message))
@@ -105,7 +105,7 @@ test_that("validate_pr flags modifications and deletions in PR", {
       gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
       pr_number = 6,
       skip_submit_window_check = TRUE,
-      file_modify_check = "none"
+      file_modification_check = "none"
     )
   )
   expect_snapshot(str(mod_checks_none))

--- a/tests/testthat/test-validate_pr.R
+++ b/tests/testthat/test-validate_pr.R
@@ -130,3 +130,30 @@ test_that("validate_pr flags modifications and deletions in PR", {
   )
   expect_snapshot(str(mod_checks_in_window))
 })
+
+
+
+test_that("validate_pr handles errors in determining submission window & file renaming", {
+  skip_if_offline()
+
+  temp_hub <- fs::path(tempdir(), "mod_exec_error_hub")
+  gert::git_clone(
+    url = "https://github.com/Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+    path = temp_hub,
+    branch = "test-exec-error-mod-delete"
+  )
+
+  mod_checks_exec_error <- suppressMessages(
+    validate_pr(
+      hub_path = temp_hub,
+      gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+      pr_number = 7,
+      skip_submit_window_check = TRUE
+    )
+  )
+  expect_snapshot(str(mod_checks_exec_error[1:5]))
+  expect_error(
+    suppressMessages(check_for_errors(mod_checks_exec_error))
+  )
+
+})

--- a/tests/testthat/test-validate_pr.R
+++ b/tests/testthat/test-validate_pr.R
@@ -69,4 +69,64 @@ test_that("validate_pr flags modifications and deletions in PR", {
   expect_error(
     suppressMessages(check_for_errors(checks))
   )
+
+  checks <- suppressMessages(
+    validate_pr(
+      hub_path = temp_hub,
+      gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+      pr_number = 6,
+      skip_submit_window_check = TRUE,
+      file_modify_check = "warn"
+    )
+  )
+  expect_snapshot(str(checks))
+  expect_error(
+    suppressMessages(check_for_errors(checks))
+  )
+
+  checks <- suppressMessages(
+    validate_pr(
+      hub_path = temp_hub,
+      gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+      pr_number = 6,
+      skip_submit_window_check = TRUE,
+      file_modify_check = "message"
+    )
+  )
+  expect_snapshot(str(checks))
+  expect_true(
+    suppressMessages(check_for_errors(checks[1:5]))
+  )
+
+
+  checks <- suppressMessages(
+    validate_pr(
+      hub_path = temp_hub,
+      gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+      pr_number = 6,
+      skip_submit_window_check = TRUE,
+      file_modify_check = "none"
+    )
+  )
+  expect_snapshot(str(checks))
+  expect_true(
+    suppressMessages(check_for_errors(checks[1:5]))
+  )
+
+  mockery::stub(
+    check_submission_time,
+    "Sys.time",
+    lubridate::as_datetime("2022-10-08 18:01:00 EEST"),
+    2
+  )
+  checks <- suppressMessages(
+    validate_pr(
+      hub_path = temp_hub,
+      gh_repo = "Infectious-Disease-Modeling-Hubs/ci-testhub-simple",
+      pr_number = 6,
+      skip_submit_window_check = TRUE,
+      allow_submit_window_mods = TRUE
+    )
+  )
+  expect_snapshot(str(checks))
 })


### PR DESCRIPTION
Hey @LucieContamin & @elray1 !

I've taken all your comments on board and introduced two new arguments to`validate_pr()` for controlling modification/deletions checks performed on model output and model metadata files.
  - `file_modify_check`, which controls whether modification/deletion checks are performed and what is retuned if modifications/deletions detected. It takes the following options: 
    - `"error"`: Appends a `<error/check_error>` condition class object for each applicable modified/deleted file.
    - `"warning"`: Appends a `<warning/check_warning>` condition class object for each applicable modified/deleted file.
    - `"message"`: Appends a `<message/check_info>` condition class object for each
applicable modified/deleted file.
    - `"none"`: No modification/deletion checks performed.
  - `allow_submit_window_mods`, which controls whether modifications/deletions of model output files are allowed within their submission windows.

They main issue I hit that ended up in some more time and complicated code than I hoped for is summarised as a note in the function docs too:

Note that to establish relative submission windows when performing modification/deletion checks and `allow_submit_window_mods` is `TRUE`, the reference date is taken as the round_id extracted from the file path (i.e. `submit_window_ref_date_from` is always set to `"file_path"`). This is because we cannot extract dates from columns of deleted files. If hub submission window reference dates do not match round IDs in file paths, currently `allow_submit_window_mods` will not work correctly and is best set to `FALSE`. This only relates to hubs/rounds where submission windows are determined relative to a reference date and not when explicit submission window start and end dates are provided in the config.

Up to now and by default in ths PR, relative submission windows have been determined using contents of the file (which follows how the config files are set up to give the reference column name relative to which the window is determined). So far this date always matched the round ID in the file path so I opted for the option above to get round the problem described. 
This does mean that two submission checks (one when we check whether the submission falls within the submission window as part of `validate_submission` (which is also used separately, locally by users) and once now when `allow_submit_window_mods` = `TRUE` and mods/deletions are detected) use two different sources of reference date to calculate the window (the former uses the file contents to follow how config is structured more faithfully and allow more flexibility while the later the file path to allow for checking deleted file windows). 

I obviously don't love this duplication and difference in ref date source but I dislike the thought of introducing irrelevant arguments to `validate_submission` in order to pass upstream arguments from `validate_pr` as well introducing functionality to handle deleted files in `validate_submission` more. 

I feel the separation of the task of checking and alerting about mods & deletions to `validate_pr()` is correct and I've tried to handle the idiosyncrasies of checking for submission windows on deleted files as best I could, especially through documentation but if you have a better suggestion or can envisage a big problem I've overlooked let me know!