### PR TITLE
Split hubutils - Release v0.0.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::tzdb
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.0.0.9008
+Version: 0.0.1
 Authors@R: c(
     person(
         given = "Anna", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,9 @@ Imports:
     dplyr,
     fs,
     gh,
-    hubUtils (>= 0.0.0.9016),
+    hubAdmin,
+    hubData,
+    hubUtils (>= 0.0.1),
     jsonlite,
     jsonvalidate,
     lubridate,
@@ -58,13 +60,15 @@ Suggests:
     testthis,
     withr
 Remotes:
-    Infectious-Disease-Modeling-Hubs/hubUtils,
+    Infectious-Disease-Modeling-Hubs/hubUtils#143,
+    Infectious-Disease-Modeling-Hubs/hubData#1,
+    Infectious-Disease-Modeling-Hubs/hubAdmin#1,
     assignUser/octolog
 Config/testthat/edition: 3
-Config/Needs/website:pkgdown, Infectious-Disease-Modeling-Hubs/hubStyle
+Config/Needs/website: pkgdown, Infectious-Disease-Modeling-Hubs/hubStyle
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/Infectious-Disease-Modeling-Hubs/hubValidations,
     https://infectious-disease-modeling-hubs.github.io/hubValidations/
 BugReports: https://github.com/Infectious-Disease-Modeling-Hubs/hubValidations/issues

--- a/R/check_config_hub_valid.R
+++ b/R/check_config_hub_valid.R
@@ -6,7 +6,7 @@
 #'
 #' @export
 check_config_hub_valid <- function(hub_path) {
-  valid_config <- hubUtils::validate_hub_config(hub_path) %>%
+  valid_config <- hubAdmin::validate_hub_config(hub_path) %>%
     suppressMessages() %>%
     suppressWarnings()
 

--- a/R/check_metadata_file_exists.R
+++ b/R/check_metadata_file_exists.R
@@ -2,7 +2,7 @@
 #'
 #' @param file_path character string. Path to the file being validated relative to
 #' the hub's model-metadata directory.
-#' @inheritParams hubUtils::connect_hub
+#' @inheritParams hubData::connect_hub
 #'
 #' @inherit check_valid_round_id return
 #'

--- a/R/check_tbl_col_types.R
+++ b/R/check_tbl_col_types.R
@@ -13,7 +13,7 @@
 check_tbl_col_types <- function(tbl, file_path, hub_path) {
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
 
-  schema <- hubUtils::create_hub_schema(config_tasks,
+  schema <- hubData::create_hub_schema(config_tasks,
     partitions = NULL,
     r_schema = TRUE
   )[names(tbl)]

--- a/R/check_tbl_colnames.R
+++ b/R/check_tbl_colnames.R
@@ -7,7 +7,7 @@
 #' @param round_id character string. The round identifier.
 #' @param file_path character string. Path to the file being validated relative to
 #' the hub's model-output directory.
-#' @inheritParams hubUtils::connect_hub
+#' @inheritParams hubData::connect_hub
 #' @return
 #' Depending on whether validation has succeeded, one of:
 #' - `<message/check_success>` condition class object.

--- a/R/check_tbl_value_col.R
+++ b/R/check_tbl_value_col.R
@@ -9,11 +9,11 @@
 check_tbl_value_col <- function(tbl, round_id, file_path, hub_path) {
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
 
-  tbl[, names(tbl) != "value"] <- hubUtils::coerce_to_character(
+  tbl[, names(tbl) != "value"] <- hubData::coerce_to_character(
     tbl[, names(tbl) != "value"]
   )
 
-  full <- hubUtils::expand_model_out_val_grid(
+  full <- hubData::expand_model_out_val_grid(
     config_tasks,
     round_id = round_id,
     required_vals_only = FALSE,

--- a/R/check_tbl_values.R
+++ b/R/check_tbl_values.R
@@ -11,7 +11,7 @@ check_tbl_values <- function(tbl, round_id, file_path, hub_path) {
   # working with larger files but currently arrow does not match NAs as dplyr
   # does, returning false positives for mean & median rows which contain NA in
   # output type ID column.
-  accepted_vals <- hubUtils::expand_model_out_val_grid(
+  accepted_vals <- hubData::expand_model_out_val_grid(
     config_tasks = config_tasks,
     round_id = round_id,
     all_character = TRUE

--- a/R/check_tbl_values_required.R
+++ b/R/check_tbl_values_required.R
@@ -8,7 +8,7 @@
 check_tbl_values_required <- function(tbl, round_id, file_path, hub_path) {
   tbl[["value"]] <- NULL
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
-  req <- hubUtils::expand_model_out_val_grid(
+  req <- hubData::expand_model_out_val_grid(
     config_tasks,
     round_id = round_id,
     required_vals_only = TRUE,
@@ -16,7 +16,7 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path) {
     bind_model_tasks = FALSE
   )
 
-  full <- hubUtils::expand_model_out_val_grid(
+  full <- hubData::expand_model_out_val_grid(
     config_tasks,
     round_id = round_id,
     required_vals_only = FALSE,
@@ -41,7 +41,7 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path) {
   if (check) {
     details <- NULL
   } else {
-    missing_df <- hubUtils::coerce_to_hub_schema(missing_df, config_tasks)
+    missing_df <- hubData::coerce_to_hub_schema(missing_df, config_tasks)
     details <- cli::format_inline("See {.var missing} attribute for details.")
   }
 

--- a/R/hub_validations_methods.R
+++ b/R/hub_validations_methods.R
@@ -73,11 +73,6 @@ validate_internal_class <- function(x, class = c(
   invisible(TRUE)
 }
 
-summary.hub_validations <- function(x, ...) {
-  # TODO
-  NULL
-}
-
 # TODO: Code to consider implementing more hierarchical printing of messages.
 # Currently not implemented as pr_hub_validations class not implemented.
 #' Print results of `validate_pr()` function as a bullet list

--- a/R/opt_check_metadata_team_max_model_n.R
+++ b/R/opt_check_metadata_team_max_model_n.R
@@ -14,7 +14,7 @@ opt_check_metadata_team_max_model_n <- function(file_path, hub_path, n_max = 2L)
     file_path,
     file_type = "model_metadata"
   )$team_abbr
-  all_model_meta <- hubUtils::load_model_metadata(hub_path)
+  all_model_meta <- hubData::load_model_metadata(hub_path)
 
   team_models <- all_model_meta[["model_abbr"]][all_model_meta[["team_abbr"]] == team_abbr]
   n_models <- length(team_models)

--- a/R/opt_check_tbl_col_timediff.R
+++ b/R/opt_check_tbl_col_timediff.R
@@ -19,7 +19,7 @@ opt_check_tbl_col_timediff <- function(tbl, file_path, hub_path,
   checkmate::assert_choice(t1_colname, choices = names(tbl))
 
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
-  schema <- hubUtils::create_hub_schema(config_tasks,
+  schema <- hubData::create_hub_schema(config_tasks,
     partitions = NULL,
     r_schema = TRUE
   )

--- a/R/opt_check_tbl_horizon_timediff.R
+++ b/R/opt_check_tbl_horizon_timediff.R
@@ -25,7 +25,7 @@ opt_check_tbl_horizon_timediff <- function(tbl, file_path, hub_path, t0_colname,
   checkmate::assert_choice(horizon_colname, choices = names(tbl))
 
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
-  schema <- hubUtils::create_hub_schema(config_tasks,
+  schema <- hubData::create_hub_schema(config_tasks,
     partitions = NULL,
     r_schema = TRUE
   )

--- a/R/read_model_out_file.R
+++ b/R/read_model_out_file.R
@@ -42,12 +42,12 @@ read_model_out_file <- function(file_path, hub_path = ".",
     parquet = {
       if (coerce_types == "hub") {
         arrow::read_parquet(full_path) %>%
-          hubUtils::coerce_to_hub_schema(
+          hubData::coerce_to_hub_schema(
             config_tasks = hubUtils::read_config(hub_path, "tasks")
           )
       } else if (coerce_types == "chr") {
         arrow::read_parquet(full_path) %>%
-          hubUtils::coerce_to_character()
+          hubData::coerce_to_character()
       } else {
         arrow::read_parquet(full_path)
       }
@@ -55,12 +55,12 @@ read_model_out_file <- function(file_path, hub_path = ".",
     arrow = {
       if (coerce_types == "hub") {
         arrow::read_feather(full_path) %>%
-          hubUtils::coerce_to_hub_schema(
+          hubData::coerce_to_hub_schema(
             config_tasks = hubUtils::read_config(hub_path, "tasks")
           )
       } else if (coerce_types == "chr") {
         arrow::read_feather(full_path) %>%
-          hubUtils::coerce_to_character()
+          hubData::coerce_to_character()
       } else {
         arrow::read_feather(full_path)
       }
@@ -72,7 +72,7 @@ read_model_out_file <- function(file_path, hub_path = ".",
 create_model_out_schema <- function(hub_path,
                                     col_types = c("hub", "chr")) {
   col_types <- rlang::arg_match(col_types)
-  schema <- hubUtils::create_hub_schema(
+  schema <- hubData::create_hub_schema(
     config_tasks = hubUtils::read_config(hub_path, "tasks"),
     partitions = NULL
   )

--- a/man/check_config_hub_valid.Rd
+++ b/man/check_config_hub_valid.Rd
@@ -8,8 +8,8 @@ check_config_hub_valid(hub_path)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_file_exists.Rd
+++ b/man/check_file_exists.Rd
@@ -15,8 +15,8 @@ check_file_exists(
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_file_format.Rd
+++ b/man/check_file_format.Rd
@@ -11,8 +11,8 @@ check_file_format(file_path, hub_path, round_id)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_file_read.Rd
+++ b/man/check_file_read.Rd
@@ -11,8 +11,8 @@ check_file_read(file_path, hub_path = ".")
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_metadata_file_exists.Rd
+++ b/man/check_metadata_file_exists.Rd
@@ -8,8 +8,8 @@ check_metadata_file_exists(hub_path = ".", file_path)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_metadata_file_name.Rd
+++ b/man/check_metadata_file_name.Rd
@@ -12,8 +12,8 @@ check_metadata_file_name(file_path, hub_path = ".")
 the hub's model-metadata directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_metadata_matches_schema.Rd
+++ b/man/check_metadata_matches_schema.Rd
@@ -11,8 +11,8 @@ check_metadata_matches_schema(file_path, hub_path = ".")
 the hub's model-metadata directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_metadata_schema_exists.Rd
+++ b/man/check_metadata_schema_exists.Rd
@@ -8,8 +8,8 @@ check_metadata_schema_exists(hub_path = ".")
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_submission_metadata_file_exists.Rd
+++ b/man/check_submission_metadata_file_exists.Rd
@@ -11,8 +11,8 @@ check_submission_metadata_file_exists(file_path, hub_path = ".")
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_submission_time.Rd
+++ b/man/check_submission_time.Rd
@@ -12,8 +12,8 @@ check_submission_time(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_col_types.Rd
+++ b/man/check_tbl_col_types.Rd
@@ -13,8 +13,8 @@ check_tbl_col_types(tbl, file_path, hub_path)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_colnames.Rd
+++ b/man/check_tbl_colnames.Rd
@@ -15,8 +15,8 @@ check_tbl_colnames(tbl, round_id, file_path, hub_path = ".")
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_match_round_id.Rd
+++ b/man/check_tbl_match_round_id.Rd
@@ -13,8 +13,8 @@ check_tbl_match_round_id(tbl, file_path, hub_path, round_id_col = NULL)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_rows_unique.Rd
+++ b/man/check_tbl_rows_unique.Rd
@@ -13,8 +13,8 @@ check_tbl_rows_unique(tbl, file_path, hub_path)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_unique_round_id.Rd
+++ b/man/check_tbl_unique_round_id.Rd
@@ -13,8 +13,8 @@ check_tbl_unique_round_id(tbl, file_path, hub_path, round_id_col = NULL)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_value_col.Rd
+++ b/man/check_tbl_value_col.Rd
@@ -15,8 +15,8 @@ check_tbl_value_col(tbl, round_id, file_path, hub_path)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_values.Rd
+++ b/man/check_tbl_values.Rd
@@ -15,8 +15,8 @@ check_tbl_values(tbl, round_id, file_path, hub_path)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_tbl_values_required.Rd
+++ b/man/check_tbl_values_required.Rd
@@ -16,8 +16,8 @@ check_tbl_values_required(tbl, round_id, file_path, hub_path)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_valid_round_id.Rd
+++ b/man/check_valid_round_id.Rd
@@ -13,8 +13,8 @@ check_valid_round_id(round_id, file_path, hub_path = ".")
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/check_valid_round_id_col.Rd
+++ b/man/check_valid_round_id_col.Rd
@@ -14,8 +14,8 @@ check_valid_round_id_col(tbl, file_path, hub_path, round_id_col = NULL)
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/opt_check_metadata_team_max_model_n.Rd
+++ b/man/opt_check_metadata_team_max_model_n.Rd
@@ -12,8 +12,8 @@ opt_check_metadata_team_max_model_n(file_path, hub_path, n_max = 2L)
 the hub's model-metadata directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/opt_check_tbl_col_timediff.Rd
+++ b/man/opt_check_tbl_col_timediff.Rd
@@ -20,8 +20,8 @@ opt_check_tbl_col_timediff(
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/opt_check_tbl_counts_lt_popn.Rd
+++ b/man/opt_check_tbl_counts_lt_popn.Rd
@@ -21,8 +21,8 @@ opt_check_tbl_counts_lt_popn(
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/opt_check_tbl_horizon_timediff.Rd
+++ b/man/opt_check_tbl_horizon_timediff.Rd
@@ -22,8 +22,8 @@ opt_check_tbl_horizon_timediff(
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/read_model_out_file.Rd
+++ b/man/read_model_out_file.Rd
@@ -15,8 +15,8 @@ read_model_out_file(
 the hub's model-output directory.}
 
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_model_data.Rd
+++ b/man/validate_model_data.Rd
@@ -13,8 +13,8 @@ validate_model_data(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_model_file.Rd
+++ b/man/validate_model_file.Rd
@@ -8,8 +8,8 @@ validate_model_file(hub_path, file_path, validations_cfg_path = NULL)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_model_metadata.Rd
+++ b/man/validate_model_metadata.Rd
@@ -13,8 +13,8 @@ validate_model_metadata(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -18,8 +18,8 @@ validate_pr(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -16,8 +16,8 @@ validate_submission(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/man/validate_submission_time.Rd
+++ b/man/validate_submission_time.Rd
@@ -12,8 +12,8 @@ validate_submission_time(
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
-or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubUtils:s3_bucket]{s3_bucket()}}
-or \code{\link[hubUtils:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
+or an object of class \verb{<SubTreeFileSystem>} created using functions \code{\link[hubData:s3_bucket]{s3_bucket()}}
+or \code{\link[hubData:gs_bucket]{gs_bucket()}} by providing a string S3 or GCS bucket name or path to a
 Modeling Hub directory stored in the cloud.
 For more details consult the
 \href{https://arrow.apache.org/docs/r/articles/fs.html}{Using cloud storage (S3, GCS)}

--- a/tests/testthat/_snaps/check_file_read.md
+++ b/tests/testthat/_snaps/check_file_read.md
@@ -1,8 +1,8 @@
 # check_file_read works
 
     Code
-      check_file_read(file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
-        hub_path = hub_path)
+      suppressMessages(check_file_read(file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
+        hub_path = hub_path))
     Output
       <message/check_success>
       Message:

--- a/tests/testthat/test-check_config_hub_valid.R
+++ b/tests/testthat/test-check_config_hub_valid.R
@@ -14,7 +14,7 @@ test_that("check_config_hub_valid works", {
 
   mockery::stub(
     check_config_hub_valid,
-    "hubUtils::validate_hub_config",
+    "hubAdmin::validate_hub_config",
     list(
       admin = TRUE,
       tasks = FALSE

--- a/tests/testthat/test-check_file_read.R
+++ b/tests/testthat/test-check_file_read.R
@@ -2,15 +2,19 @@ test_that("check_file_read works", {
   hub_path <- system.file("testhubs/simple", package = "hubValidations")
 
   expect_snapshot(
-    check_file_read(
-      file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
-      hub_path = hub_path
+    suppressMessages(
+      check_file_read(
+        file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
+        hub_path = hub_path
+      )
     )
   )
   expect_s3_class(
-    check_file_read(
-      file_path = "team1-goodmodel/2022-10-15-team1-goodmodel.csv",
-      hub_path = hub_path
+    suppressMessages(
+      check_file_read(
+        file_path = "team1-goodmodel/2022-10-15-team1-goodmodel.csv",
+        hub_path = hub_path
+      )
     ),
     c("check_error", "hub_check", "rlang_error", "error", "condition")
   )

--- a/tests/testthat/test-check_tbl_col_types.R
+++ b/tests/testthat/test-check_tbl_col_types.R
@@ -9,7 +9,7 @@ test_that("check_tbl_col_types works", {
 
   mockery::stub(
     check_tbl_col_types,
-    "hubUtils::create_hub_schema",
+    "hubData::create_hub_schema",
     c(
       origin_date = "character", target = "character", horizon = "double",
       location = "character", age_group = "character", output_type = "character",

--- a/tests/testthat/test-check_tbl_value_col_ascending.R
+++ b/tests/testthat/test-check_tbl_value_col_ascending.R
@@ -20,7 +20,7 @@ test_that("check_tbl_value_col_ascending works when output type IDs not ordered"
   tbl <- arrow::read_csv_arrow(
     test_path("testdata/files/2024-01-10-ISI-NotOrdered.csv")
   ) %>%
-    hubUtils::coerce_to_character()
+    hubData::coerce_to_character()
   file_path <- "ISI-NotOrdered/2024-01-10-ISI-NotOrdered.csv"
   expect_snapshot(
     check_tbl_value_col_ascending(tbl, file_path)

--- a/tests/testthat/test-opt_check_tbl_col_timediff.R
+++ b/tests/testthat/test-opt_check_tbl_col_timediff.R
@@ -13,7 +13,7 @@ test_that("opt_check_tbl_col_timediff works", {
     )
   )
 
-  tbl_chr <- hubUtils::coerce_to_character(tbl)
+  tbl_chr <- hubData::coerce_to_character(tbl)
   expect_snapshot(
     opt_check_tbl_col_timediff(tbl_chr, file_path, hub_path,
       t0_colname = "forecast_date",
@@ -73,7 +73,7 @@ test_that("opt_check_tbl_col_timediff fails correctly", {
   )
   mockery::stub(
     opt_check_tbl_col_timediff,
-    "hubUtils::create_hub_schema",
+    "hubData::create_hub_schema",
     schema,
     2
   )

--- a/tests/testthat/test-opt_check_tbl_horizon_timediff.R
+++ b/tests/testthat/test-opt_check_tbl_horizon_timediff.R
@@ -11,7 +11,7 @@ test_that("opt_check_tbl_horizon_timediff works", {
     )
   )
 
-  tbl_chr <- hubUtils::coerce_to_character(tbl)
+  tbl_chr <- hubData::coerce_to_character(tbl)
   expect_snapshot(
     opt_check_tbl_horizon_timediff(tbl_chr, file_path, hub_path,
       t0_colname = "forecast_date",
@@ -74,7 +74,7 @@ test_that("opt_check_tbl_horizon_timediff fails correctly", {
   )
   mockery::stub(
     opt_check_tbl_horizon_timediff,
-    "hubUtils::create_hub_schema",
+    "hubData::create_hub_schema",
     schema,
     2
   )


### PR DESCRIPTION
Add functionality split from `hubUtils`

Details of the split can be found in `hubUtils`  `NEWS.md`, reproduced below:

> * First **major release of `hubUtils` package** containing significant breaking changes. Much of the package has been moved and split across two smaller and more dedicated packages:
>  - **`hubData` package**: contains functions for connecting to and interacting with hub data. 
>    * Exported functions moved to `hubData`: `connect_hub()`, `connect_model_output()`, `expand_model_out_val_grid()`, `create_model_out_submit_tmpl()`, `coerce_to_character()`, `coerce_to_hub_schema()` and `create_hub_schema()`.
>    * `hubUtils` functions re-exported to `hubData`: `as_model_out_tbl()`, `validate_model_out_tbl()`, `model_id_split()` and `model_id_merge()`.
>  - **`hubAdmin` package**: contains functions for administering Hubs, in particular creating and validating hub configuration files. Exported functions moved to `hubAdmin`: 
>    * Functions for creating config files: `create_config()`, `create_model_task()`, `create_model_tasks()`, `create_output_type()`, `create_output_type_cdf()`, `create_output_type_mean()`, `create_output_type_median()`, `create_output_type_pmf()`, `create_output_type_quantile()`, `create_output_type_sample()`, `create_round()`, `create_rounds()`, `create_target_metadata()`, `create_target_metadata_item()`, `create_task_id()`, `create_task_ids()`.
 >   * Functions for validating config files: `validate_config()`,`validate_model_metadata_schema()`, `validate_hub_config()`, `view_config_val_errors()`.